### PR TITLE
update top 5 to top 3 parameters

### DIFF
--- a/group_project_2.ipynb
+++ b/group_project_2.ipynb
@@ -2,18 +2,16 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "89999d54",
+   "id": "12777bb5",
    "metadata": {},
    "source": [
     "# S&P 500 Signal Classifier"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b144d472",
+   "cell_type": "markdown",
+   "id": "ba4022e4",
    "metadata": {},
-   "outputs": [],
    "source": [
     "Approach:\n",
     "1. Create features\n",
@@ -26,7 +24,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14637a31",
+   "id": "6c76c56a",
    "metadata": {},
    "source": [
     "## Install Required Packages"
@@ -35,7 +33,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c47187e7",
+   "id": "e1a79391",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -46,7 +44,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d902262e",
+   "id": "2e54d932",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,7 +55,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87a8c897",
+   "id": "2ff72741",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -68,7 +66,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44cb0b57",
+   "id": "9c6250d5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,7 +76,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ab56bdba",
+   "id": "9a17ee1c",
    "metadata": {},
    "source": [
     "## Import Required Dependencies"
@@ -114,7 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b0b9a13d",
+   "id": "cfc577dd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -126,7 +124,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f2ce4834",
+   "id": "fd0bef82",
    "metadata": {},
    "source": [
     "## Retrieve and Load Data"
@@ -135,7 +133,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "97ac395f",
+   "id": "ea57f0fd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -147,7 +145,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2b43f4ab",
+   "id": "bb2a43f1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -160,7 +158,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "448c188d",
+   "id": "bcb98bdd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -171,7 +169,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78f8c185",
+   "id": "aa460c76",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -182,7 +180,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cac61841",
+   "id": "b7b7931e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -194,7 +192,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f5d3c244",
+   "id": "c847522a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -212,7 +210,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b8c33b36",
+   "id": "b412c11b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -222,7 +220,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8cee8f50",
+   "id": "739cd3af",
    "metadata": {},
    "source": [
     "## Perform Feature Engineering"
@@ -231,7 +229,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3a20cf04",
+   "id": "353f7e8f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -284,7 +282,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c178fe26",
+   "id": "cb5fb92c",
    "metadata": {},
    "source": [
     "## Perform Feature Engineering"
@@ -293,7 +291,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42a640a3",
+   "id": "93943d86",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -346,7 +344,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5142009b",
+   "id": "7396bced",
    "metadata": {},
    "source": [
     "## Perform Winsorization of Data"
@@ -355,7 +353,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "af3b4a81",
+   "id": "6c84b2a6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -382,7 +380,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "040f89e8",
+   "id": "4c04afbe",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -394,7 +392,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c42020e2",
+   "id": "74ec9371",
    "metadata": {},
    "source": [
     "## Perform Train and Test Splits"
@@ -403,7 +401,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6b1cf841",
+   "id": "45bc62f5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -417,7 +415,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d08c3bf6",
+   "id": "a005ab33",
    "metadata": {},
    "source": [
     "## Perform Scaling"
@@ -426,7 +424,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8e770cb3",
+   "id": "e6b0be73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -442,7 +440,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12d9d326",
+   "id": "e1065e98",
    "metadata": {},
    "source": [
     "# Perform Classifications"
@@ -450,7 +448,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b39e8223",
+   "id": "b4cdc1b0",
    "metadata": {},
    "source": [
     "## Original Scaled Data with Untuned RandomForestClassifier"
@@ -459,7 +457,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7f13e07b",
+   "id": "468a843c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -493,7 +491,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "548cc6ca",
+   "id": "f81a4916",
    "metadata": {},
    "source": [
     "## Over Sampled Scaled Data with Untuned RandomForestClassifier"
@@ -502,7 +500,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51e417c7",
+   "id": "cc7f6250",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -522,7 +520,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "091af750",
+   "id": "83aa481e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -556,7 +554,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6c3ef0ea",
+   "id": "a63b6544",
    "metadata": {},
    "source": [
     "## Under Sampled Scaled Data with Untuned RandomForestClassifier"
@@ -565,7 +563,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46a32429",
+   "id": "b1c3690c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -585,7 +583,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21020a65",
+   "id": "ab56c3cd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -619,7 +617,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "da0a2633",
+   "id": "ce5c7bfb",
    "metadata": {},
    "source": [
     "## Original Scaled Data and Untuned XGBoost Classifier"
@@ -628,7 +626,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c5c14fa7",
+   "id": "f24acbfd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -667,7 +665,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a2497c4c",
+   "id": "43b866da",
    "metadata": {},
    "source": [
     "## Under Sampled Scaled Data and Untuned XGBoost Classifier"
@@ -676,7 +674,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bb1db0e7",
+   "id": "6e41f94b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -714,7 +712,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f224fbc9",
+   "id": "2410a26a",
    "metadata": {},
    "source": [
     "## Under Sampled Scaled Data with XGBoost Parameter Tuning"
@@ -723,7 +721,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b929a62b",
+   "id": "f4dcf8b1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -756,27 +754,27 @@
     "models_df = pd.DataFrame(models).set_index('learning_rate')\n",
     "\n",
     "# Display df\n",
-    "display(models_df.sort_values(by='test_score', ascending=False).head(5))"
+    "display(models_df.sort_values(by='test_score', ascending=False).head(3))"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8b085bd6",
+   "id": "8882675f",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Sort the dataframe by test_score in descending order and get the top 5\n",
-    "top_learning_rates = models_df.sort_values(by='test_score', ascending=False).head(5).index.tolist()\n",
+    "# Sort the dataframe by test_score in descending order and get the top 3\n",
+    "top_learning_rates = models_df.sort_values(by='test_score', ascending=False).head(3).index.tolist()\n",
     "\n",
-    "# Display the top 5 \n",
+    "# Display the top 3 \n",
     "top_learning_rates"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "beb6a5c0",
+   "id": "02c5ab95",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -787,7 +785,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d870fe32",
+   "id": "f7be1f8b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -820,27 +818,27 @@
     "models_df = pd.DataFrame(models).set_index('n_estimators')\n",
     "\n",
     "# Display df\n",
-    "display(models_df.sort_values(by='test_score', ascending=False).head(5))"
+    "display(models_df.sort_values(by='test_score', ascending=False).head(3))"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ae670c80",
+   "id": "97b70bf9",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Sort the dataframe by test_score in descending order and get the top 5\n",
-    "top_n_estimators = models_df.sort_values(by='test_score', ascending=False).head(5).index.tolist()\n",
+    "# Sort the dataframe by test_score in descending order and get the top 3\n",
+    "top_n_estimators = models_df.sort_values(by='test_score', ascending=False).head(3).index.tolist()\n",
     "\n",
-    "# Display the top 5\n",
+    "# Display the top 3\n",
     "top_n_estimators"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "042e81b9",
+   "id": "50e8bee1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -851,7 +849,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7f33f41e",
+   "id": "5d18aa4a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -884,27 +882,27 @@
     "models_df = pd.DataFrame(models).set_index('max_depth')\n",
     "\n",
     "# Display df\n",
-    "display(models_df.sort_values(by='test_score', ascending=False).head(5))"
+    "display(models_df.sort_values(by='test_score', ascending=False).head(3))"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "631758e8",
+   "id": "30ac51f6",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Sort the dataframe by test_score in descending order and get the top 5\n",
-    "top_max_depth = models_df.sort_values(by='test_score', ascending=False).head(5).index.tolist()\n",
+    "# Sort the dataframe by test_score in descending order and get the top 3\n",
+    "top_max_depth = models_df.sort_values(by='test_score', ascending=False).head(3).index.tolist()\n",
     "\n",
-    "# Display the top 5\n",
+    "# Display the top 3\n",
     "top_max_depth"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7dbdf012",
+   "id": "54c39448",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -915,7 +913,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b10b7dcc",
+   "id": "99afd16c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -948,27 +946,27 @@
     "models_df = pd.DataFrame(models).set_index('max_leaves')\n",
     "\n",
     "# Display df\n",
-    "display(models_df.sort_values(by='test_score', ascending=False).head(5))"
+    "display(models_df.sort_values(by='test_score', ascending=False).head(3))"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "db2ed420",
+   "id": "5c97605d",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Sort the dataframe by test_score in descending order and get the top 5\n",
-    "top_max_leaves = models_df.sort_values(by='test_score', ascending=False).head(5).index.tolist()\n",
+    "# Sort the dataframe by test_score in descending order and get the top 3\n",
+    "top_max_leaves = models_df.sort_values(by='test_score', ascending=False).head(3).index.tolist()\n",
     "\n",
-    "# Display the top 5\n",
+    "# Display the top 3\n",
     "top_max_leaves"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aef09b02",
+   "id": "37bc8dab",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -979,7 +977,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ba16afd9",
+   "id": "754bbeab",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1012,27 +1010,27 @@
     "models_df = pd.DataFrame(models).set_index('subsample')\n",
     "\n",
     "# Display df\n",
-    "display(models_df.sort_values(by='test_score', ascending=False).head(5))"
+    "display(models_df.sort_values(by='test_score', ascending=False).head(3))"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2968e9b6",
+   "id": "d23b9e74",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Sort the dataframe by test_score in descending order and get the top 5\n",
-    "top_subsample = models_df.sort_values(by='test_score', ascending=False).head(5).index.tolist()\n",
+    "# Sort the dataframe by test_score in descending order and get the top 3\n",
+    "top_subsample = models_df.sort_values(by='test_score', ascending=False).head(3).index.tolist()\n",
     "\n",
-    "# Display the top 5\n",
+    "# Display the top 3\n",
     "top_subsample"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ad897c8f",
+   "id": "99f9b153",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1043,11 +1041,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "352cb8e3",
+   "id": "a4f5fed6",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Dictionary with 5 values for each parameter\n",
+    "# Dictionary with 3 values for each parameter\n",
     "params = {\n",
     "    'n_estimators': top_n_estimators,\n",
     "    'max_depth': top_max_depth,\n",
@@ -1095,18 +1093,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2bf6c073",
+   "id": "f6978395",
    "metadata": {},
    "outputs": [],
    "source": [
     "sorted_results_df = results_df.sort_values(by='test_score', ascending=False)\n",
-    "print(sorted_results_df.head(5))"
+    "print(sorted_results_df.head(3))"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5d2894d9",
+   "id": "72f37304",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1140,7 +1138,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8007c949",
+   "id": "16537c28",
    "metadata": {},
    "source": [
     "## Original Scaled Data and Untuned LightBoost"
@@ -1149,7 +1147,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d7bd93d5",
+   "id": "e0768593",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1183,7 +1181,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "44a0ac9d",
+   "id": "69d6886a",
    "metadata": {},
    "source": [
     "## Under Sampled Scaled Data with Untuned LightBoost"
@@ -1192,7 +1190,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ccd508a5",
+   "id": "935cf374",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1226,7 +1224,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "67cfad49",
+   "id": "b8adb829",
    "metadata": {},
    "source": [
     "## RandomUnderSampler Data with Tuned Lightboost Classifier"
@@ -1235,7 +1233,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36fdfd2f",
+   "id": "ca87b2d2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1267,27 +1265,27 @@
     "models_df = pd.DataFrame(models).set_index('learning_rate')\n",
     "\n",
     "# Display df\n",
-    "display(models_df.sort_values(by='test_score', ascending=False).head(5))"
+    "display(models_df.sort_values(by='test_score', ascending=False).head(3))"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20787b69",
+   "id": "934b83fa",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Sort the dataframe by test_score in descending order and get the top 5\n",
-    "learning_rate = models_df.sort_values(by='test_score', ascending=False).head(5).index.tolist()\n",
+    "# Sort the dataframe by test_score in descending order and get the top 3\n",
+    "learning_rate = models_df.sort_values(by='test_score', ascending=False).head(3).index.tolist()\n",
     "\n",
-    "# Display the top 5 max_depths\n",
+    "# Display the top 3 \n",
     "learning_rate"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2ce0b53a",
+   "id": "0c532d33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1306,7 +1304,7 @@
     "estimators = range(100, 250, 1)\n",
     "models = {'train_score': [], 'test_score': [], 'n_estimators': []}\n",
     "\n",
-    "# Loop through each value in max_depths\n",
+    "# Loop through each value in n_estimators\n",
     "for n in estimators:\n",
     "    # Initialize the classifier with current parameters\n",
     "    lgb_rus_clf =lgb.LGBMClassifier(n_estimators = n, random_state=1, verbose=-1)\n",
@@ -1331,27 +1329,27 @@
     "models_df = pd.DataFrame(models).set_index('n_estimators')\n",
     "\n",
     "# Display df\n",
-    "display(models_df.sort_values(by='test_score', ascending=False).head(5))"
+    "display(models_df.sort_values(by='test_score', ascending=False).head(3))"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2da9c95f",
+   "id": "f9bfc2a9",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Sort the dataframe by test_score in descending order and get the top 5\n",
-    "n_estimators = models_df.sort_values(by='test_score', ascending=False).head(5).index.tolist()\n",
+    "# Sort the dataframe by test_score in descending order and get the top 3\n",
+    "n_estimators = models_df.sort_values(by='test_score', ascending=False).head(3).index.tolist()\n",
     "\n",
-    "# Display the top 5 max_depths\n",
+    "# Display the top 3\n",
     "n_estimators"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fb8a5b9e",
+   "id": "be2539dc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1362,7 +1360,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9b194687",
+   "id": "b85bb408",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1395,27 +1393,27 @@
     "models_df = pd.DataFrame(models).set_index('max_depth')\n",
     "\n",
     "# Display df\n",
-    "display(models_df.sort_values(by='test_score', ascending=False).head(5))"
+    "display(models_df.sort_values(by='test_score', ascending=False).head(3))"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2fb1f68a",
+   "id": "854d39fb",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Sort the dataframe by test_score in descending order and get the top 5\n",
-    "max_depth = models_df.sort_values(by='test_score', ascending=False).head(5).index.tolist()\n",
+    "# Sort the dataframe by test_score in descending order and get the top 3\n",
+    "max_depth = models_df.sort_values(by='test_score', ascending=False).head(3).index.tolist()\n",
     "\n",
-    "# Display the top 5 max_depths\n",
+    "# Display the top 3 \n",
     "max_depth"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c9fcc093",
+   "id": "acbd2b9e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1426,15 +1424,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ec3fba95",
+   "id": "45bdbb0f",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Try the following values for num_iterations\n",
+    "# Try the following values for num_leaves\n",
     "num_leaves = range(10, 50)\n",
     "models = {'train_score': [], 'test_score': [], 'num_leaves': []}\n",
     "\n",
-    "# Loop through each value in max_depths\n",
+    "# Loop through each value in num_leaves\n",
     "for num in num_leaves:\n",
     "    # Initialize the classifier with current parameters\n",
     "    lgb_rus_clf = lgb.LGBMClassifier(num_leaves = num, random_state=1, verbose=-1)\n",
@@ -1459,27 +1457,27 @@
     "models_df = pd.DataFrame(models).set_index('num_leaves')\n",
     "\n",
     "# Display df\n",
-    "display(models_df.sort_values(by='test_score', ascending=False).head(5))"
+    "display(models_df.sort_values(by='test_score', ascending=False).head(3))"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c4e32b20",
+   "id": "807fbdbb",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Sort the dataframe by test_score in descending order and get the top 5\n",
-    "num_leaves = models_df.sort_values(by='test_score', ascending=False).head(5).index.tolist()\n",
+    "# Sort the dataframe by test_score in descending order and get the top 3\n",
+    "num_leaves = models_df.sort_values(by='test_score', ascending=False).head(3).index.tolist()\n",
     "\n",
-    "# Display the top 5 max_depths\n",
+    "# Display the top 3 \n",
     "num_leaves"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "332bbc39",
+   "id": "53af1877",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1490,7 +1488,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "532f6261",
+   "id": "dfe9c89e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1498,7 +1496,7 @@
     "max_bin = range(20, 512, 1)\n",
     "models = {'train_score': [], 'test_score': [], 'max_bin': []}\n",
     "\n",
-    "# Loop through each value in max_depths\n",
+    "# Loop through each value in max_bins\n",
     "for bin in max_bin:\n",
     "    # Initialize the classifier with current parameters\n",
     "    lgb_rus_clf = lgb.LGBMClassifier(max_bin = bin, random_state=1, verbose=-1)\n",
@@ -1523,27 +1521,27 @@
     "models_df = pd.DataFrame(models).set_index('max_bin')\n",
     "\n",
     "# Display df\n",
-    "display(models_df.sort_values(by='test_score', ascending=False).head(5))"
+    "display(models_df.sort_values(by='test_score', ascending=False).head(3))"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "09110b05",
+   "id": "62e4d3d9",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Sort the dataframe by test_score in descending order and get the top 5\n",
-    "max_bin = models_df.sort_values(by='test_score', ascending=False).head(5).index.tolist()\n",
+    "# Sort the dataframe by test_score in descending order and get the top 3\n",
+    "max_bin = models_df.sort_values(by='test_score', ascending=False).head(3).index.tolist()\n",
     "\n",
-    "# Display the top 5 max_depths\n",
+    "# Display the top 3 \n",
     "max_bin"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c50ce283",
+   "id": "5bd701ab",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1554,11 +1552,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "98145a9e",
+   "id": "3e63403b",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Dictionary with 5 values for each parameter\n",
+    "# Dictionary with 3 values for each parameter\n",
     "params = {\n",
     "    'n_estimators': n_estimators,\n",
     "    'max_depth': max_depth,\n",
@@ -1606,18 +1604,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b069f83d",
+   "id": "8f5dbc1b",
    "metadata": {},
    "outputs": [],
    "source": [
     "sorted_results_df = results_df.sort_values(by='test_score', ascending=False)\n",
-    "print(sorted_results_df.head(5))"
+    "print(sorted_results_df.head(3))"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a14d3ad6",
+   "id": "7745513e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1632,7 +1630,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87b1a99c",
+   "id": "e43355ca",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1644,7 +1642,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d7d0ab39",
+   "id": "241db64e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1669,7 +1667,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d524c946",
+   "id": "dc2b3106",
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
This code was changed from 5 to 3:

display(models_df.sort_values(by='test_score', ascending=False).head(3))

# Sort the dataframe by test_score in descending order and get the top 3
top_max_leaves = models_df.sort_values(by='test_score', ascending=False).head(3).index.tolist()
# Display the top 3

# Dictionary with 3 values for each parameter
params = {

sorted_results_df = results_df.sort_values(by='test_score', ascending=False)
print(sorted_results_df.head(3))